### PR TITLE
Add redner modes to env metadata for video recording

### DIFF
--- a/envs/procgen_env_wrapper.py
+++ b/envs/procgen_env_wrapper.py
@@ -28,6 +28,8 @@ class ProcgenEnvWrapper(gym.Env):
 
         env = gym.make(f"procgen:procgen-{self.env_name}-v0", **self.config)
         self.env = env
+        # Enable video recording features
+        self.metadata = {"render.modes": ["rgb_array", "human"]}
 
         self.action_space = self.env.action_space
         self.observation_space = self.env.observation_space

--- a/rollout.py
+++ b/rollout.py
@@ -14,7 +14,12 @@ import gym.wrappers
 import ray
 from ray.rllib.env import MultiAgentEnv
 from ray.rllib.env.base_env import _DUMMY_AGENT_ID
-from ray.rllib.utils.space_utils import flatten_to_single_ndarray
+try:
+    from ray.rllib.evaluation.episode import _flatten_action
+except Exception:
+    # For newer ray versions
+    from ray.rllib.utils.space_utils import flatten_to_single_ndarray as _flatten_action
+
 from ray.rllib.evaluation.worker_set import WorkerSet
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.utils.deprecation import deprecation_warning
@@ -372,7 +377,7 @@ def rollout(agent,
         use_lstm = {DEFAULT_POLICY_ID: False}
 
     action_init = {
-        p: flatten_to_single_ndarray(m.action_space.sample())
+        p: _flatten_action(m.action_space.sample())
         for p, m in policy_map.items()
     }
 
@@ -422,7 +427,7 @@ def rollout(agent,
                             prev_action=prev_actions[agent_id],
                             prev_reward=prev_rewards[agent_id],
                             policy_id=policy_id)
-                    a_action = flatten_to_single_ndarray(a_action)  # tuple actions
+                    a_action = _flatten_action(a_action)  # tuple actions
                     action_dict[agent_id] = a_action
                     prev_actions[agent_id] = a_action
             action = action_dict


### PR DESCRIPTION
Adds `metadata` to `ProcgenEnvWrapper` for the videos to get generated by gym monitor.