### PR TITLE
Fix s3 artifact issues for custom docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM ubuntu:18.04
+FROM nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt -qq update && apt -qq install -y --no-install-recommends \
     wget \
+    ca-certificates \
     locales \
     libglib2.0 \
-    libsm6 \
     libsm6 \
     libxext6 \
     libxrender-dev \
     xvfb \
+    ffmpeg \
     freeglut3-dev \
  && rm -rf /var/cache/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ RUN apt -qq update && apt -qq install -y --no-install-recommends \
     freeglut3-dev \
  && rm -rf /var/cache/*
 
+# S3 client
+RUN wget -nv -O ./mc https://dl.min.io/client/mc/release/linux-amd64/mc \
+ && mv ./mc /bin/mc && chmod +x /bin/mc
+
 # Unicode support:
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ray[rllib]==0.8.5
 procgen==0.10.1
 tensorflow==2.1.0
-mlflow
+mlflow==1.8.0
+boto3==1.13.10


### PR DESCRIPTION
- Add `mc` to copy the videos generated during rollouts.
- Add `boto3` pip package which required by `mlflow` to copy artifacts.